### PR TITLE
Add new release step to build for multiple platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+on:
+  push:
+    tags: ["*"]
+jobs:
+  build-binaries:
+    name: Build Go Binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, windows/386, windows/amd64, darwin/386, darwin/amd64
+        goos: [linux, windows, darwin]
+        goarch: ["386", amd64, arm64]
+        include:
+          - goos: windows
+            extension: .exe
+          - goos: linux
+            extension: ""
+          - goos: darwin
+            extension: ""
+        exclude:
+          # No windows/arm64
+          - goos: windows
+            goarch: arm64
+          # No darwin/386
+          - goos: darwin
+            goarch: "386"
+          # No darwin/arm64 support / working yet (for desktop)
+          # should come out with go 1.16 https://github.com/golang/go/issues/38485
+          - goos: darwin
+            goarch: arm64
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      EXT: ${{ matrix.extension }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          go build -o dist/opadynamo_${GOOS}_${GOARCH}${EXT} main.go
+          ls dist
+      - name: Upload Artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: dist
+          path: dist
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [build-binaries]
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@master
+        with:
+          name: dist
+          path: dist
+      - name: Variables
+        env:
+          REF: ${{ github.ref }}
+        run: echo ::set-output name=version::${REF/refs\/tags\/}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ steps.Variables.outputs.version }}
+          body: ${{ github.event.head_commit.message }}
+          draft: true
+          prerelease: false
+      - name: Upload release binaries
+        uses: alexellis/upload-assets@0.2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_paths: '["./dist/*"]'
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .devcontainer/extensions
 cover.html
+dist
 
 # Created by https://www.toptal.com/developers/gitignore/api/go,vscode,windows,linux
 # Edit at https://www.toptal.com/developers/gitignore?templates=go,vscode,windows,linux


### PR DESCRIPTION
Automatically build and release binaries when a new tag
is created.